### PR TITLE
Add email-validator dependency for WTForms email validation

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -1,3 +1,4 @@
 -e file:../odp-core
 -e file:../odp-ui
 gunicorn
+email-validator

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,6 +26,10 @@ click==8.1.8
     # via flask
 cryptography==44.0.2
     # via authlib
+dnspython==2.8.0
+    # via email-validator
+email-validator==2.3.0
+    # via -r requirements.in
 flask==2.3.3
     # via
     #   flask-login
@@ -35,7 +39,9 @@ flask-login==0.6.3
 gunicorn==23.0.0
     # via -r requirements.in
 idna==3.10
-    # via requests
+    # via
+    #   email-validator
+    #   requests
 itsdangerous==2.2.0
     # via flask
 jinja2==3.1.6


### PR DESCRIPTION
DownloadAuditForm's email field uses WTForms' email() validator, which requires the email_validator package at runtime. It was missing from requirements.txt, causing ModuleNotFoundError on /catalog/download-audit submissions.